### PR TITLE
Factor PatchSet out of PathFTB into separate PatchStep type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone local dependencies
+        env:
+          GH_TOKEN: ${{ secrets.DEPS_TOKEN }}
         run: |
           mkdir -p deps
+
+          # Configure git to use token for private repos
+          if [ -n "$GH_TOKEN" ]; then
+            git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+
           git clone --depth 1 https://github.com/massudaw/patch.git            deps/patch
           git clone --depth 1 https://github.com/massudaw/master-plan.git       deps/master-plan
           git clone --depth 1 https://github.com/massudaw/postgresql-simple.git deps/postgresql-simple

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clone local dependencies
+        run: |
+          mkdir -p deps
+          git clone --depth 1 https://github.com/massudaw/patch.git            deps/patch
+          git clone --depth 1 https://github.com/massudaw/master-plan.git       deps/master-plan
+          git clone --depth 1 https://github.com/massudaw/postgresql-simple.git deps/postgresql-simple
+          git clone --depth 1 https://github.com/massudaw/ordered.git           deps/ordered
+          git clone --depth 1 https://github.com/massudaw/GiST.git             deps/GiST
+          git clone --depth 1 https://github.com/massudaw/extended-reals.git    deps/extended-reals
+          git clone --depth 1 https://github.com/massudaw/data-interval.git     deps/data-interval
+          git clone --depth 1 https://github.com/massudaw/threepenny-gui.git    deps/threepenny-gui
+
+      - uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: 'latest'
+
+      - name: Cache Stack work
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack
+            .stack-work
+            core/.stack-work
+            browser/.stack-work
+            plugins/.stack-work
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-${{ hashFiles('stack.yaml') }}-
+            ${{ runner.os }}-stack-
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev libssl-dev
+
+      - name: Build dependencies
+        run: stack build --only-dependencies
+
+      - name: Build project
+        run: stack build

--- a/core/src/Types/Patch.hs
+++ b/core/src/Types/Patch.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Types.Patch
   -- Class Patch Interface
@@ -52,7 +53,8 @@ module Types.Patch
   , kvlistp
   , recoverPFK
   , liftPFK
-  , PathFTB(..)
+  , PatchStep(..)
+  , PathFTB(PatchOne, PatchSet, PAtom, POpt, PIdx, PInter)
   , PathTID(..)
   , upperPatch
   , lowerPatch
@@ -188,15 +190,53 @@ nonRefPatch i = Map.singleton (index i )  (content i)
 kvsingleton :: Address a => a -> Map (Idx a) (Content a)
 kvsingleton i = Map.singleton (index i)  (content i)
 
+-- | Structural patch step — one level of navigation into an FTB tree.
+--   Separated from 'PathFTB' so that functions which only need to handle
+--   structural cases can pattern-match exhaustively without a 'PatchSet' arm.
+data PatchStep a
+  = PAtomS a
+  | POptS (Maybe (PathFTB a))
+  | PIdxS Int
+          (Maybe (PathFTB a))
+  | PInterS Bool
+             (Extended (PathFTB a), Bool)
+  deriving (Eq, Ord, Functor, Generic, Foldable, Traversable)
+
+-- | A patch on an 'FTB' value: either a single structural step ('PatchOne')
+--   or a sequence of patches to apply in order ('PatchSet').
 data PathFTB a
-  = PAtom a
-  | POpt (Maybe (PathFTB a))
-  | PIdx Int
-         (Maybe (PathFTB a))
-  | PInter Bool
-           (Extended (PathFTB a), Bool)
+  = PatchOne !(PatchStep a)
   | PatchSet (Non.NonEmpty (PathFTB a))
-  deriving (Show, Eq, Ord, Functor, Generic, Foldable, Traversable)
+  deriving (Eq, Ord, Functor, Generic, Foldable, Traversable)
+
+-- Backward-compatible pattern synonyms
+pattern PAtom :: a -> PathFTB a
+pattern PAtom a = PatchOne (PAtomS a)
+
+pattern POpt :: Maybe (PathFTB a) -> PathFTB a
+pattern POpt a = PatchOne (POptS a)
+
+pattern PIdx :: Int -> Maybe (PathFTB a) -> PathFTB a
+pattern PIdx i a = PatchOne (PIdxS i a)
+
+pattern PInter :: Bool -> (Extended (PathFTB a), Bool) -> PathFTB a
+pattern PInter b a = PatchOne (PInterS b a)
+
+{-# COMPLETE PAtom, POpt, PIdx, PInter, PatchSet #-}
+
+-- Custom Show that uses the pattern synonym names for readability
+instance Show a => Show (PatchStep a) where
+  showsPrec d (PAtomS a) = showParen (d > 10) $ showString "PAtomS " . showsPrec 11 a
+  showsPrec d (POptS a) = showParen (d > 10) $ showString "POptS " . showsPrec 11 a
+  showsPrec d (PIdxS i a) = showParen (d > 10) $ showString "PIdxS " . showsPrec 11 i . showChar ' ' . showsPrec 11 a
+  showsPrec d (PInterS b a) = showParen (d > 10) $ showString "PInterS " . showsPrec 11 b . showChar ' ' . showsPrec 11 a
+
+instance Show a => Show (PathFTB a) where
+  showsPrec d (PAtom a) = showParen (d > 10) $ showString "PAtom " . showsPrec 11 a
+  showsPrec d (POpt a) = showParen (d > 10) $ showString "POpt " . showsPrec 11 a
+  showsPrec d (PIdx i a) = showParen (d > 10) $ showString "PIdx " . showsPrec 11 i . showChar ' ' . showsPrec 11 a
+  showsPrec d (PInter b a) = showParen (d > 10) $ showString "PInter " . showsPrec 11 b . showChar ' ' . showsPrec 11 a
+  showsPrec d (PatchSet l) = showParen (d > 10) $ showString "PatchSet " . showsPrec 11 l
 
 data PatchFTBC  a 
  = PAtomicC a
@@ -664,8 +704,10 @@ instance (Binary k, Binary a) => Binary (PathAttr k a)
 
 instance (NFData k, NFData a) => NFData (PathAttr k a)
 
+instance (NFData k) => NFData (PatchStep k)
 instance (NFData k) => NFData (PathFTB k)
 
+instance (Binary k) => Binary (PatchStep k)
 instance (Binary k) => Binary (PathFTB k)
 
 traverseWithAttr f = Map.traverseWithKey (\k -> fmap content . f . rebuild k )


### PR DESCRIPTION
Introduce PatchStep with the 4 structural constructors (PAtomS, POptS,
PIdxS, PInterS) and redefine PathFTB as PatchOne (PatchStep a) | PatchSet.
Bidirectional pattern synonyms (PAtom, POpt, PIdx, PInter) preserve full
backward compatibility — all existing code compiles unchanged.

This separation allows new code to pattern-match exhaustively on
PatchStep without handling PatchSet, making structural traversals
total and easier to reason about.

https://claude.ai/code/session_01WnyMoVVgF24cqFZdotsgpd